### PR TITLE
Fix deploy errors

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,0 +1,30 @@
+# base-image for node on any machine using a template variable,
+# see more about dockerfile templates here: http://docs.resin.io/deployment/docker-templates/
+# and about resin base images here: http://docs.resin.io/runtime/resin-base-images/
+# Note the node:slim image doesn't have node-gyp
+FROM resin/%%RESIN_MACHINE_NAME%%-node:6
+
+# use apt-get if you need to install dependencies,
+# for instance if you need ALSA sound utils, just uncomment the lines below.
+#RUN apt-get update && apt-get install -yq \
+#    alsa-utils libasound2-dev && \
+#    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Defines our working directory in container
+WORKDIR /usr/src/app
+
+# Copies the package.json first for better cache on later pushes
+COPY package.json package.json
+
+# This install npm dependencies on the resin.io build server,
+# making sure to clean up the artifacts it creates in order to reduce the image size.
+RUN JOBS=MAX npm install --production --unsafe-perm && npm cache clean && rm -rf /tmp/*
+
+# This will copy all files in our root to the working  directory in the container
+COPY . ./
+
+# Enable systemd init system in container
+ENV INITSYSTEM on
+
+# server.js will run when container starts up on the device
+CMD ["npm", "start"]

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   },
   "devDependencies": {},
   "scripts": {
-    "preinstall": "bash deps.sh",
     "start": "node app.js"
   }
 }


### PR DESCRIPTION
These changes allow this project to push to balena without fatal errors. The Dockerfile is copied from https://github.com/balena-io-projects/simple-server-node, but does not use node-slim.